### PR TITLE
Checkboxes are "checked" rather than "selected".

### DIFF
--- a/angular-auto-value.js
+++ b/angular-auto-value.js
@@ -53,6 +53,7 @@
       var set = setter($parse, $scope, $attrs.ngModel),
           value = $element.val(),
           selected = $attrs.selected,
+          checked = $attrs.checked,
           method;
       switch ($attrs.type) {
         case "button":
@@ -63,7 +64,7 @@
         case "submit":
           return;
         case "checkbox":
-          set(selected);
+          set(checked);
           break;
         case "number":
         case "range":

--- a/test/autoValueSpec.html
+++ b/test/autoValueSpec.html
@@ -135,7 +135,7 @@
           <div class="form-group">
             <div class="col-xs-12">
               <label class="checkbox-inline">
-                <input name="checkbox[]" data-ng-model="checkboxMung" selected type="checkbox" value="mung"/>
+                <input name="checkbox[]" data-ng-model="checkboxMung" checked type="checkbox" value="mung"/>
                 Mung
               </label>
               <label class="checkbox-inline">


### PR DESCRIPTION
Hi John, thanks for the useful library!

I've just been using your code in a Django project today and noticed that it's expecting checkboxes to be "selected", when I think they're actually meant to be "checked", as per https://www.w3.org/TR/html-markup/input.checkbox.html.

I wasn't able to run the tests unfortunately - likely to be my version of Node or something. Just so you know.

Cheers,
Ben