### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ bower i --save angular-auto-value
 ### CDN
 
 ```html
-<script src="//cdn.jsdelivr.net/angular.auto-value/latest/angular-auto-value.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/angular-auto-value@latest/angular-auto-value.min.js"></script>
 ```
 
 Testing


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/angular-auto-value.

Feel free to ping me if you have any questions regarding this change.